### PR TITLE
[FEAT] Calendar View(2) 구현

### DIFF
--- a/bonheur/Sources/ViewControllers/CalendarView/CalendarViewController.swift
+++ b/bonheur/Sources/ViewControllers/CalendarView/CalendarViewController.swift
@@ -102,7 +102,7 @@ class CalendarViewController: UIViewController {
     }
     
     func configureUI() {
-        view.backgroundColor = .systemGray5
+        view.backgroundColor = .white
         
         let stack = UIStackView(arrangedSubviews: [sadImageView, notiTextLabel])
         stack.axis = .vertical
@@ -133,9 +133,7 @@ class CalendarViewController: UIViewController {
         calendar.translatesAutoresizingMaskIntoConstraints = false
         calendar.collectionView.translatesAutoresizingMaskIntoConstraints = false
         
-        //calendarHeightAnchor = calendar.heightAnchor.constraint(equalToConstant: 480)
-        calendarHeightAnchor = calendar.heightAnchor.constraint(equalToConstant: 475)
-        
+        calendarHeightAnchor = calendar.heightAnchor.constraint(equalToConstant: 465)
         
         NSLayoutConstraint.activate([
             calendar.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 28),
@@ -150,7 +148,7 @@ class CalendarViewController: UIViewController {
         ])
         
         changeWeekMonthButton.translatesAutoresizingMaskIntoConstraints = false
-        changeWeekMonthButtonAnchor = changeWeekMonthButton.topAnchor.constraint(equalTo: calendar.bottomAnchor, constant: 10)
+        changeWeekMonthButtonAnchor = changeWeekMonthButton.topAnchor.constraint(equalTo: calendar.bottomAnchor, constant: 1)
         
         NSLayoutConstraint.activate([
             changeWeekMonthButtonAnchor,
@@ -188,18 +186,21 @@ class CalendarViewController: UIViewController {
         calendar.placeholderType = .none
         calendar.appearance.selectionColor = .red
         calendar.appearance.titleSelectionColor = .black
-        calendar.appearance.imageOffset = CGPoint(x: 0, y: -50)
         calendar.appearance.todayColor = .clear
         calendar.appearance.titleTodayColor = UIColor(red: 94/255, green: 156/255, blue: 3/255, alpha: 1)
         calendar.weekdayHeight = 30
+        calendar.headerHeight = 35
         calendar.adjustsBoundingRectWhenChangingMonths = true
         
-        // temp color for autoLayout
-        calendar.calendarWeekdayView.backgroundColor = .blue
-        calendar.collectionView.backgroundColor = .white
-        calendar.contentView.backgroundColor = .cyan
-        calendar.daysContainer.backgroundColor = .brown
+        calendar.appearance.titleOffset = CGPoint(x: 0, y: 10)
+        calendar.appearance.imageOffset = CGPoint(x: 0, y: -47)
         
+        // temp color for autoLayout
+//        calendar.calendarWeekdayView.backgroundColor = .blue
+//        calendar.collectionView.backgroundColor = .purple
+//        calendar.contentView.backgroundColor = .cyan
+//        calendar.daysContainer.backgroundColor = .brown
+//
 
 
     }
@@ -230,15 +231,15 @@ class CalendarViewController: UIViewController {
         if self.calendar.scope == .month {
             self.calendar.setScope(.week, animated: true)
             self.changeWeekMonthButton.setImage(CalendarIcon.downIcon, for: .normal)
-            calendar.appearance.imageOffset = CGPoint(x: 0, y: 0)
-            calendar.weekdayHeight = 15
-            changeWeekMonthButtonAnchor.constant = -3
+//            calendar.appearance.imageOffset = CGPoint(x: 0, y: 0)
+//            calendar.weekdayHeight = 15
+//            changeWeekMonthButtonAnchor.constant = -3
         } else {
             self.calendar.setScope(.month, animated: true)
             self.changeWeekMonthButton.setImage(CalendarIcon.upIcon, for: .normal)
-            calendar.appearance.imageOffset = CGPoint(x: 0, y: -50)
-            calendar.weekdayHeight = 30
-            changeWeekMonthButtonAnchor.constant = -20
+//            calendar.appearance.imageOffset = CGPoint(x: 0, y: -50)
+//            calendar.weekdayHeight = 30
+//            changeWeekMonthButtonAnchor.constant = -20
         }
     }
 }

--- a/bonheur/Sources/ViewControllers/CalendarView/CalendarViewController.swift
+++ b/bonheur/Sources/ViewControllers/CalendarView/CalendarViewController.swift
@@ -67,7 +67,6 @@ class CalendarViewController: UIViewController {
         button.titleLabel?.font = UIFont(name: "SFPro-Bold", size: 16)
         button.setTitleColor(.black, for: .normal)
         button.addTarget(self, action: #selector(tapTodayButton), for: .touchUpInside)
-
         return button
     }()
     
@@ -98,7 +97,6 @@ class CalendarViewController: UIViewController {
         configureCalendar()
         configureUI()
         configureNavBar()
-        
     }
     
     func configureUI() {
@@ -178,7 +176,6 @@ class CalendarViewController: UIViewController {
         calendar.delegate = self
         
         calendar.register(FSCalendarCell.self, forCellReuseIdentifier: "CELL")
-        view.addSubview(calendar)
         self.calendar = calendar
         
         calendar.appearance.headerTitleColor = .clear
@@ -186,26 +183,17 @@ class CalendarViewController: UIViewController {
         calendar.appearance.weekdayFont = UIFont(name: "SFPro-Regular", size: 14)
         calendar.appearance.titleFont = UIFont(name: "SFPro-Regular", size: 14)
         calendar.appearance.weekdayTextColor = UIColor.black
-        calendar.placeholderType = .none
-        calendar.appearance.selectionColor = .red
+        calendar.appearance.selectionColor = .clear
         calendar.appearance.titleSelectionColor = .black
         calendar.appearance.todayColor = .clear
         calendar.appearance.titleTodayColor = UIColor(red: 94/255, green: 156/255, blue: 3/255, alpha: 1)
-        calendar.weekdayHeight = 30
-        calendar.headerHeight = 35
-        calendar.adjustsBoundingRectWhenChangingMonths = true
-        
         calendar.appearance.titleOffset = CGPoint(x: 0, y: 10)
         calendar.appearance.imageOffset = CGPoint(x: 0, y: -47)
         
-        // temp color for autoLayout
-        
-//        calendar.calendarWeekdayView.backgroundColor = .blue
-//        calendar.collectionView.backgroundColor = .purple
-//        calendar.contentView.backgroundColor = .cyan
-//        calendar.daysContainer.backgroundColor = .brown
-//        calendar.calendarHeaderView.backgroundColor = .red
-
+        calendar.weekdayHeight = 30
+        calendar.headerHeight = 35
+        calendar.placeholderType = .none
+        calendar.adjustsBoundingRectWhenChangingMonths = true
     }
     
     func getNextMonth(date: Date) -> Date {
@@ -234,15 +222,9 @@ class CalendarViewController: UIViewController {
         if self.calendar.scope == .month {
             self.calendar.setScope(.week, animated: true)
             self.changeWeekMonthButton.setImage(CalendarIcon.downIcon, for: .normal)
-//            calendar.appearance.imageOffset = CGPoint(x: 0, y: 0)
-//            calendar.weekdayHeight = 15
-//            changeWeekMonthButtonAnchor.constant = -3
         } else {
             self.calendar.setScope(.month, animated: true)
             self.changeWeekMonthButton.setImage(CalendarIcon.upIcon, for: .normal)
-//            calendar.appearance.imageOffset = CGPoint(x: 0, y: -50)
-//            calendar.weekdayHeight = 30
-//            changeWeekMonthButtonAnchor.constant = -20
         }
     }
 }

--- a/bonheur/Sources/ViewControllers/CalendarView/CalendarViewController.swift
+++ b/bonheur/Sources/ViewControllers/CalendarView/CalendarViewController.swift
@@ -102,7 +102,7 @@ class CalendarViewController: UIViewController {
     }
     
     func configureUI() {
-        view.backgroundColor = .white
+        view.backgroundColor = .systemGray5
         
         let stack = UIStackView(arrangedSubviews: [sadImageView, notiTextLabel])
         stack.axis = .vertical
@@ -131,17 +131,26 @@ class CalendarViewController: UIViewController {
         calendarButtonStackView.trailingAnchor.constraint(equalTo: calendar.collectionView.trailingAnchor, constant: -13).isActive = true
         
         calendar.translatesAutoresizingMaskIntoConstraints = false
-        calendarHeightAnchor = calendar.heightAnchor.constraint(equalToConstant: 435)
+        calendar.collectionView.translatesAutoresizingMaskIntoConstraints = false
+        
+        //calendarHeightAnchor = calendar.heightAnchor.constraint(equalToConstant: 480)
+        calendarHeightAnchor = calendar.heightAnchor.constraint(equalToConstant: 475)
+        
         
         NSLayoutConstraint.activate([
             calendar.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 28),
             calendar.centerXAnchor.constraint(equalTo: view.centerXAnchor),
             calendarHeightAnchor,
-            calendar.widthAnchor.constraint(equalToConstant: view.frame.width - 40)
+            calendar.widthAnchor.constraint(equalToConstant: view.frame.width - 40),
+            
+            calendar.collectionView.heightAnchor.constraint(equalToConstant: 412),
+            calendar.collectionView.widthAnchor.constraint(equalToConstant: view.frame.width - 40),
+            calendar.collectionView.topAnchor.constraint(equalTo: calendar.calendarWeekdayView.bottomAnchor, constant: 8)
+            
         ])
         
         changeWeekMonthButton.translatesAutoresizingMaskIntoConstraints = false
-        changeWeekMonthButtonAnchor = changeWeekMonthButton.topAnchor.constraint(equalTo: calendar.bottomAnchor, constant: -20)
+        changeWeekMonthButtonAnchor = changeWeekMonthButton.topAnchor.constraint(equalTo: calendar.bottomAnchor, constant: 10)
         
         NSLayoutConstraint.activate([
             changeWeekMonthButtonAnchor,
@@ -177,12 +186,22 @@ class CalendarViewController: UIViewController {
         calendar.appearance.titleFont = UIFont(name: "SFPro-Regular", size: 14)
         calendar.appearance.weekdayTextColor = UIColor.black
         calendar.placeholderType = .none
-        calendar.appearance.selectionColor = .clear
+        calendar.appearance.selectionColor = .red
         calendar.appearance.titleSelectionColor = .black
-        calendar.appearance.imageOffset = CGPoint(x: 0, y: -45)
+        calendar.appearance.imageOffset = CGPoint(x: 0, y: -50)
         calendar.appearance.todayColor = .clear
         calendar.appearance.titleTodayColor = UIColor(red: 94/255, green: 156/255, blue: 3/255, alpha: 1)
         calendar.weekdayHeight = 30
+        calendar.adjustsBoundingRectWhenChangingMonths = true
+        
+        // temp color for autoLayout
+        calendar.calendarWeekdayView.backgroundColor = .blue
+        calendar.collectionView.backgroundColor = .white
+        calendar.contentView.backgroundColor = .cyan
+        calendar.daysContainer.backgroundColor = .brown
+        
+
+
     }
     
     func getNextMonth(date: Date) -> Date {
@@ -214,12 +233,10 @@ class CalendarViewController: UIViewController {
             calendar.appearance.imageOffset = CGPoint(x: 0, y: 0)
             calendar.weekdayHeight = 15
             changeWeekMonthButtonAnchor.constant = -3
-        }
-        
-        else {
+        } else {
             self.calendar.setScope(.month, animated: true)
             self.changeWeekMonthButton.setImage(CalendarIcon.upIcon, for: .normal)
-            calendar.appearance.imageOffset = CGPoint(x: 0, y: -45)
+            calendar.appearance.imageOffset = CGPoint(x: 0, y: -50)
             calendar.weekdayHeight = 30
             changeWeekMonthButtonAnchor.constant = -20
         }

--- a/bonheur/Sources/ViewControllers/CalendarView/CalendarViewController.swift
+++ b/bonheur/Sources/ViewControllers/CalendarView/CalendarViewController.swift
@@ -182,7 +182,7 @@ class CalendarViewController: UIViewController {
         calendar.appearance.headerMinimumDissolvedAlpha = 0.0
         calendar.appearance.weekdayFont = UIFont(name: "SFPro-Regular", size: 14)
         calendar.appearance.titleFont = UIFont(name: "SFPro-Regular", size: 14)
-        calendar.appearance.weekdayTextColor = UIColor.black
+        calendar.appearance.weekdayTextColor = .black
         calendar.appearance.selectionColor = .clear
         calendar.appearance.titleSelectionColor = .black
         calendar.appearance.todayColor = .clear

--- a/bonheur/Sources/ViewControllers/CalendarView/CalendarViewController.swift
+++ b/bonheur/Sources/ViewControllers/CalendarView/CalendarViewController.swift
@@ -131,6 +131,7 @@ class CalendarViewController: UIViewController {
         calendarButtonStackView.trailingAnchor.constraint(equalTo: calendar.collectionView.trailingAnchor, constant: -13).isActive = true
         
         calendar.translatesAutoresizingMaskIntoConstraints = false
+        calendar.calendarHeaderView.translatesAutoresizingMaskIntoConstraints = false
         calendar.collectionView.translatesAutoresizingMaskIntoConstraints = false
         
         calendarHeightAnchor = calendar.heightAnchor.constraint(equalToConstant: 465)
@@ -140,6 +141,8 @@ class CalendarViewController: UIViewController {
             calendar.centerXAnchor.constraint(equalTo: view.centerXAnchor),
             calendarHeightAnchor,
             calendar.widthAnchor.constraint(equalToConstant: view.frame.width - 40),
+            
+            calendar.calendarHeaderView.bottomAnchor.constraint(equalTo: calendar.calendarWeekdayView.topAnchor, constant: -25),
             
             calendar.collectionView.heightAnchor.constraint(equalToConstant: 412),
             calendar.collectionView.widthAnchor.constraint(equalToConstant: view.frame.width - 40),
@@ -196,12 +199,12 @@ class CalendarViewController: UIViewController {
         calendar.appearance.imageOffset = CGPoint(x: 0, y: -47)
         
         // temp color for autoLayout
+        
 //        calendar.calendarWeekdayView.backgroundColor = .blue
 //        calendar.collectionView.backgroundColor = .purple
 //        calendar.contentView.backgroundColor = .cyan
 //        calendar.daysContainer.backgroundColor = .brown
-//
-
+//        calendar.calendarHeaderView.backgroundColor = .red
 
     }
     


### PR DESCRIPTION
## 관련 이슈
🔒 Closes  
<!-- 관련있는 이슈 번호(#000)를 적으면 자동으로 해당 이슈를 close합니다. -->
#26 

## 작업내용
<!-- 작업 내용과 이미지를 첨부해주세요. -->
- [x] Calendar Week 사이의 간격 조정 - (1)
- [x] Calendar HeaderView 간격 해결 - (1)
- [x] 달력의 주(week)가 6개인 경우 Clover Image가 짤리는 문제 해결 - (2)
- [x] Month mode에서 Week mode로 변경 시 Clover Image가 날짜 아래로 가는 문제 해결 - (3)
- [x] Clover Image와 날짜의 클릭 이벤트가 서로 다른 문제 해결 - (4)
<br>
<!-- (+스크린샷)이 있다면 적어주세요. 없으면 지워주세요-->

### Calendar UI 수정(간격 등) - (1)

|Layout 작업 전|Layout 작업 후|
|:---:|:---:|
|<img width="250" src="https://user-images.githubusercontent.com/100567791/215094875-fe421e2a-7ba3-4a1e-930e-2c7cbdae2a8d.png">|<img width="250" src="https://user-images.githubusercontent.com/100567791/215327367-e29d60f5-bbc2-4c18-87e3-d614d2cae6c3.png">|

<br>

### 달력의 주(week)가 6개인 경우 Clover Image가 짤리는 문제 해결  - (2)

|작업 전|작업 후|
|:---:|:---:|
|<img width="250" src="https://user-images.githubusercontent.com/100567791/215392627-b59c5bc3-3170-4eeb-97db-5f5a81dfb462.png">|<img width="250" src="https://user-images.githubusercontent.com/100567791/215392096-705402cb-a1f5-4085-9550-215cc1f548e7.gif">

<br>

### Month mode에서 Week mode로 변경 시 Clover Image가 날짜 아래로 가는 문제 해결 - (3)

|작업 전|작업 후|
|:---:|:---:|
|<img width="250" src="https://user-images.githubusercontent.com/100567791/215393610-7a8df0d5-89f7-4dc5-917f-d2029b7fcf68.png">|<img width="250" src="https://user-images.githubusercontent.com/100567791/215396961-ac6c99cc-7dc3-4391-b3ae-23ae4227189b.gif">

<br>

### Clover Image와 날짜의 클릭 이벤트가 서로 다른 문제 해결 - (4)

|작업 전|작업 후|
|:---:|:---:|
|<img width="250" src="https://user-images.githubusercontent.com/100567791/215395686-bae350d4-5da6-4201-beea-101d5a25b719.gif">|<img width="250" src="https://user-images.githubusercontent.com/100567791/215396488-d1df2a53-97a3-4b8a-9005-c3aa1ba3802f.gif">

## 추후 진행할 사항

<!-- 추후에 진행할 사항들에 대해 적어주세요. -->
- 오늘 날짜를 선택했을 경우 text color가 검정으로 변하는 문제 수정
- 행복 기록 CollectionView 추가하기

## 리뷰포인트
<!-- 리뷰가 필요한 포인트와 해당 되는 커밋을 링크로 걸어주세요. -->
- 전체 4차 회의에서 캘린더의 문제로 언급한 내용을 모두 수정했습니다.
    - Calendar Week 사이의 간격을 조절하였습니다.
    - Calendar HeaderView와 Calendar WeekView 사이의 간격을 조절하였습니다.
    - 달력의 주(week)가 6개인 경우 Clover Image가 짤리는 문제를 해결하였습니다.
    - Month mode에서 Week mode로 변경 시 Clover Image가 날짜 아래로 가는 문제를 해결하였습니다.
    - Clover Image와 날짜의 클릭 이벤트가 서로 다른 문제를 해결하였습니다.
- Week 사이의 간격을 조절하는 것이 직접적으로 변경하는 것이 불가능하여 calendar의 heightAnchor와 collectionView의 heightAnchor의 값의 변경을 통해 간접적으로 조절하였습니다.
    - 이 부분에서 시간을 많이 소비하게 되었는데 날짜 위에 Image가 있는 Calendar(대부분 날짜 아래에 Image가 있거나 점으로 표시됨)가 별로 없을 뿐만 아니라 week 사이의 간격을 줄이는 방법에 대해 정보가 없어서 직접 코드를 하나하나 비교해가면서 시간이 좀 걸리게 되었습니다.
 
## Reference
<!-- 참고한 자료를 작성해주세요 -->
- https://github.com/WenchaoD/FSCalendar/issues/1291

## Checklist
- [x] 빌드를 위해 SceneDelegate 수정한 것 PR로 올리지 않았는지 확인
- [x] 필요없는 주석, 프린트문 제거했는지 확인
- [x] 컨벤션 지켰는지 확인


